### PR TITLE
404NotFoundの際の処理を修正

### DIFF
--- a/pages/ltd-news/detail/[slug].vue
+++ b/pages/ltd-news/detail/[slug].vue
@@ -1,6 +1,6 @@
 <template>
   <ClientOnly>
-    <div>
+    <div v-if="!errorFlg">
       <UiPageHeader
         :path="[{ label: '会員限定コンテンツ', to: '/ltd-news/' }]"
         subject="会員限定コンテンツ"
@@ -60,6 +60,9 @@
         </template>
       </div>
     </div>
+    <div v-else>
+      <p>error</p>
+    </div>
   </ClientOnly>
 </template>
 
@@ -67,6 +70,8 @@
 const config = useRuntimeConfig();
 
 const { isLoggedIn } = useAuth();
+
+const errorFlg = ref(false);
 
 const route = useRoute();
 // use $fetch() instead of useFetch() to avoid using cache.
@@ -78,5 +83,8 @@ const response = await $fetch(
     credentials: 'include',
     server: false,
   }
-).catch((error) => console.info(error));
+).catch((error) => {
+  console.info(error)
+  errorFlg.value = true;
+});
 </script>

--- a/public/kuroco_front.json
+++ b/public/kuroco_front.json
@@ -1,11 +1,8 @@
 {
-    "rewrites": [
-        {
-          "source": ".*",
-          "destination": "/index.html"
-        }
-      ],
     "redirects": [],
     "basic":[],
+    "error_page": {
+      "status404":"/404.html"
+    },
     "ip_restrictions":[]
 }


### PR DESCRIPTION
会員限定ページ（詳細）でリロードまたはURLに直接アクセスするとトップへリダイレクトされる #4
上記issueを解決しました。
ご確認お願いします。

例：
https://dev-nuxt-corporate.g.kuroco-front.app/ltd-news/detail/9